### PR TITLE
Virtual destructors for robots

### DIFF
--- a/enki/Geometry.h
+++ b/enki/Geometry.h
@@ -50,6 +50,10 @@
 #define round(x) floor((x) + 0.5)
 #endif
 
+#ifndef M_PI
+#define M_PI (3.14159265358979323846)
+#endif
+
 /*!	\file Geometry.h
 	\brief The mathematic classes for 2D geometry
 */

--- a/enki/robots/e-puck/EPuck.h
+++ b/enki/robots/e-puck/EPuck.h
@@ -116,7 +116,7 @@ namespace Enki
 		//! Create a E-Puck with certain modules aka capabilities (basic)
 		EPuck(unsigned capabilities = CAPABILITY_BASIC_SENSORS);
 		//! Destructor
-		~EPuck();
+		virtual ~EPuck();
 		
 		//! Set ring color (true = red, false = black) 
 		void setLedRing(bool status);

--- a/enki/robots/khepera/Khepera.cpp
+++ b/enki/robots/khepera/Khepera.cpp
@@ -69,5 +69,8 @@ namespace Enki
 		
 		setCylindric(2.6, 5, 80);
 	}
+
+    Khepera::~Khepera() {
+    }
 }
 

--- a/enki/robots/khepera/Khepera.h
+++ b/enki/robots/khepera/Khepera.h
@@ -83,6 +83,7 @@ namespace Enki
 	public:
 		//! Create a Khepera with certain modules aka capabilities (basic)
 		Khepera(unsigned capabilities = CAPABILITIY_BASIC_SENSORS);
+        virtual ~Khepera();
 	};
 }
 

--- a/enki/robots/marxbot/Marxbot.cpp
+++ b/enki/robots/marxbot/Marxbot.cpp
@@ -73,5 +73,8 @@ namespace Enki
 		unsigned physicalNumber = (24 + 12 - number) % 24;
 		return marxbotVirtualBumperResponseFunction(sqrt(rotatingDistanceSensor.zbuffer[(physicalNumber * 180) / 24]) - getRadius());
 	}
+
+    Marxbot::~Marxbot() {
+    }
 }
 

--- a/enki/robots/marxbot/Marxbot.h
+++ b/enki/robots/marxbot/Marxbot.h
@@ -60,7 +60,7 @@ namespace Enki
 		//! Constructor
 		Marxbot();
 		//! Destructor
-		~Marxbot() {}
+		~Marxbot();
 		//! Return the value of a virtual bumper
 		double getVirtualBumper(unsigned number);
 	};

--- a/enki/robots/s-bot/Sbot.cpp
+++ b/enki/robots/s-bot/Sbot.cpp
@@ -119,6 +119,9 @@ namespace Enki
 		
 		setCylindric(6, 15, 500);
 	}
+
+    Sbot::~Sbot() {
+    }
 	
 	unsigned SbotGlobalSound::worldFrequenciesState = 0;
 	

--- a/enki/robots/s-bot/Sbot.h
+++ b/enki/robots/s-bot/Sbot.h
@@ -108,7 +108,7 @@ namespace Enki
 		//! Constructor
 		Sbot();
 		//! Destructor
-		~Sbot() {}
+		~Sbot();
 	};
 
 


### PR DESCRIPTION
In Aseba, robots classes are extended. Because there was no virtual destructor in them there is no guarantee to call their's destructors. As so I added them.