### PR TITLE
maint: Define Emacs indentation rules for all the files.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,8 +2,7 @@
 ;;; For more information see (info "(emacs) Directory Variables")
 
 ((nil
-  (fill-column . 80))
- (c++-mode
+  (fill-column . 80)
   (c-file-style . "bsd")
   (c-basic-offset . 4)
   (tab-width . 4)))


### PR DESCRIPTION
"*.h" files was not properly handled by Emacs since they are using c-mode by
default and the indentation was only set for c++-mode.