### PR TITLE
Adding a unique identifier for each object

### DIFF
--- a/enki/PhysicalEngine.cpp
+++ b/enki/PhysicalEngine.cpp
@@ -1117,6 +1117,11 @@ namespace Enki
 	
 	void World::addObject(PhysicalObject *o)
 	{
+		if (o->getId() == 0)
+		{
+			o->id = idNewObject;
+			idNewObject++;
+		}
 		objects.insert(o);
 	}
 

--- a/enki/PhysicalEngine.cpp
+++ b/enki/PhysicalEngine.cpp
@@ -46,6 +46,9 @@
 
 namespace Enki
 {
+	//switching to an std::atomic<unsigned> when in the future we switch to C++11
+	static unsigned int uidNewObject = 0;
+
 	FastRandom random;
 	
 	// PhysicalObject::Part
@@ -234,7 +237,8 @@ namespace Enki
 		viscousMomentFrictionCoefficient(0.01),
 		angle(0),
 		angSpeed(0),
-		interlacedDistance(0)
+		interlacedDistance(0),
+		uid(uidNewObject++)
 	{
 		setCylindric(1, 1, 1);
 	}
@@ -1117,11 +1121,6 @@ namespace Enki
 	
 	void World::addObject(PhysicalObject *o)
 	{
-		if (o->getId() == 0)
-		{
-			o->id = idNewObject;
-			idNewObject++;
-		}
 		objects.insert(o);
 	}
 

--- a/enki/PhysicalEngine.h
+++ b/enki/PhysicalEngine.h
@@ -374,14 +374,10 @@ namespace Enki
 		void collideWithObject(PhysicalObject &that, Point cp, const Vector &dist);
 
 	public:
-		int getId() const { return id; }
-		void setId(int id) { this->id = id; }
-
-	private:
 		// ID is used when sharing a world over the network where it should be
 		// possible to associate client objects with their corresponding ones on
 		// the server even if they don't have the same pointer address.
-		int id;
+		unsigned int uid;
 	};
 
 	//! A robot is a PhysicalObject that has additional interactions and a controller.
@@ -516,9 +512,6 @@ namespace Enki
 	protected:
 		//! Can implement world specific control. By default do nothing
 		virtual void controlStep(double dt) { }
-
-	private:
-		int idNewObject;
 	};
 	
 	//! Fast random for use by Enki

--- a/enki/PhysicalEngine.h
+++ b/enki/PhysicalEngine.h
@@ -372,6 +372,16 @@ namespace Enki
 		void collideWithStaticObject(const Vector &n, const Point &cp);
 		//! Dynamics for collision with that at point cp (on that) with a penetrated distance of dist,
 		void collideWithObject(PhysicalObject &that, Point cp, const Vector &dist);
+
+	public:
+		int getId() const { return id; }
+		void setId(int id) { this->id = id; }
+
+	private:
+		// ID is used when sharing a world over the network where it should be
+		// possible to associate client objects with their corresponding ones on
+		// the server even if they don't have the same pointer address.
+		int id;
 	};
 
 	//! A robot is a PhysicalObject that has additional interactions and a controller.
@@ -506,6 +516,9 @@ namespace Enki
 	protected:
 		//! Can implement world specific control. By default do nothing
 		virtual void controlStep(double dt) { }
+
+	private:
+		int idNewObject;
 	};
 	
 	//! Fast random for use by Enki

--- a/enki/PhysicalEngine.h
+++ b/enki/PhysicalEngine.h
@@ -374,9 +374,9 @@ namespace Enki
 		void collideWithObject(PhysicalObject &that, Point cp, const Vector &dist);
 
 	public:
-		// ID is used when sharing a world over the network where it should be
-		// possible to associate client objects with their corresponding ones on
-		// the server even if they don't have the same pointer address.
+		//! ID is used when sharing a world over the network where it should be
+		//! possible to associate client objects with their corresponding ones on
+		//! the server even if they don't have the same pointer address.
 		unsigned int uid;
 	};
 


### PR DESCRIPTION
Hello,

During our programming with david Sherman, We had to create a remote view of a simulation.

To realize this project successfully, we were faced with a problem, which was that the objects did not have unique identification, so it was impossible for us to identify each object in the remote view.

We were therefore obliged to add an identifier to each ``PhyscalObject`` of the simulation.

This minor modification will allow enki to add a remote view.

What do you think?