### PR TITLE
Jenkinsfile new parallel syntax, work around JENKINS-41225

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,51 +8,58 @@ pipeline {
 	stages {
 		stage('Prepare') {
 			steps {
-				dir('enki') {
-					checkout scm
-				}
-				stash includes: 'enki/**', excludes: '.git', name: 'source'
+				checkout scm
 			}
 		}
 		stage('Compile') {
-			steps {
-				parallel (
-					"debian" : {
-						node('debian') {
-							unstash 'source'
-							script {
-								env.debian_python = sh ( script: '''
+			parallel {
+				stage("Compile on debian") {
+					agent {
+						label 'debian'
+					}
+					steps {
+						script {
+							env.debian_python = sh ( script: '''
 									python -c "import sys; print 'lib/python'+str(sys.version_info[0])+'.'+str(sys.version_info[1])+'/dist-packages'"
 ''', returnStdout: true).trim()
-							}
-							CMake([sourceDir: pwd()+'/enki', label: 'debian', getCmakeArgs: "-DPYTHON_CUSTOM_TARGET:PATH=${env.debian_python}"])
-							stash includes: 'dist/**', name: 'dist-debian'
-							stash includes: 'build/**', name: 'build-debian'
 						}
-					},
-					"macos" : {
-						node('macos') {
-							unstash 'source'
-							CMake([sourceDir: pwd()+'/enki', label: 'macos'])
-							stash includes: 'dist/**', name: 'dist-macos'
-						}
-					},
-					"windows" : {
-						node('windows') {
-							unstash 'source'
-							CMake([sourceDir: pwd()+'/enki', label: 'windows'])
-							stash includes: 'dist/**', name: 'dist-windows'
-						}
+						CMake([label: 'debian',
+							   getCmakeArgs: "-DPYTHON_CUSTOM_TARGET:PATH=${env.debian_python}"])
+						stash includes: 'dist/**', name: 'dist-debian'
+						stash includes: 'build/**', name: 'build-debian'
 					}
-				)
+				}
+				stage("Compile on macos") {
+					agent {
+						label 'macos'
+					}
+					steps {
+						CMake([label: 'macos'])
+						stash includes: 'dist/**', name: 'dist-macos'
+					}
+				}
+				stage("Compile on windows") {
+					agent {
+						label 'windows'
+					}
+					steps {
+						CMake([label: 'windows'])
+						stash includes: 'dist/**', name: 'dist-windows'
+					}
+				}
 			}
 		}
 		stage('Test') {
-			steps {
-				node('debian') {
-					unstash 'build-debian'
-					dir('build/debian') {
-						sh 'LANG=C ctest'
+			parallel {
+				stage("Test on debian") {
+					agent {
+						label 'debian'
+					}
+					steps {
+						unstash 'build-debian'
+						dir('build/debian') {
+							sh 'LANG=C ctest'
+						}
 					}
 				}
 			}
@@ -64,38 +71,29 @@ pipeline {
 					return env.BRANCH == 'master'
 				}
 			}
-			steps {
-				parallel (
-					"debian" : {
-						node('debian') {
-							unstash 'dist-debian'
-							unstash 'source'
-							dir('enki') {
-								sh 'which debuild && debuild -i -us -uc -b'
-							}
-							sh 'mv libenki*.deb libenki*.changes libenki*.build dist/debian/'
-							stash includes: 'dist/**', name: 'dist-debian'
-						}
+			parallel {
+				stage("Build debian package") {
+					agent {
+						label 'debian'
 					}
-				)
+					steps {
+						dir('build/debian/package') {
+							// We must rebuild in a subdirectory to prevent debuild from polluting the workspace parent
+							sh 'git clone --depth 1 --single-branch $GIT_URL'
+							sh '(cd enki && which debuild && debuild -i -us -uc -b)'
+							sh 'mv libenki*.deb libenki*.changes libenki*.build $WORKSPACE/dist/debian/'
+						}
+						stash includes: 'dist/**', name: 'dist-debian'
+					}
+				}
 			}
 		}
 		stage('Archive') {
 			steps {
-				script {
-					// Can't use collectEntries yet [JENKINS-26481]
-					def p = [:]
-					for (x in ['debian','macos','windows']) {
-						def label = x
-						p[label] = {
-							node(label) {
-								unstash 'dist-' + label
-								archiveArtifacts artifacts: 'dist/**', fingerprint: true, onlyIfSuccessful: true
-							}
-						}
-					}
-					parallel p;
-				}
+				unstash 'dist-debian'
+				unstash 'dist-macos'
+				unstash 'dist-windows'
+				archiveArtifacts artifacts: 'dist/**', fingerprint: true, onlyIfSuccessful: true
 			}
 		}
 	}


### PR DESCRIPTION
Jenkinsfile using the new [declarative parallel stages](https://jenkins.io/blog/2017/09/25/declarative-1/) for debian, macos, windows

Relies on davidjsherman/aseba-jenkins@e6c2eb6a6b5e262f072671d04717466945f3fb30 _et seq._: on Windows use powershell to work around regression [JENKINS-41225](https://issues.jenkins-ci.org/browse/JENKINS-41225) introduced by JENKINS-40734.

Improved SCM use lets Jenkins handle checkout without using stash and compiles at workspace root.