### PR TITLE
Qt5 for continuous integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,8 @@ pipeline {
 						label 'macos'
 					}
 					steps {
-						CMake([label: 'macos'])
+						CMake([label: 'macos',
+							   getCmakeArgs: "-DCMAKE_PREFIX_PATH=/usr/local/opt/qt5"])
 						stash includes: 'dist/**', name: 'dist-macos'
 					}
 				}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
 				}
 				stage("Compile on windows") {
 					agent {
-						label 'windows'
+						label 'windows-qt5'
 					}
 					steps {
 						CMake([label: 'windows'])

--- a/viewer/CMakeLists.txt
+++ b/viewer/CMakeLists.txt
@@ -18,7 +18,9 @@ if (Qt5Widgets_FOUND AND Qt5OpenGL_FOUND)
 	qt5_add_resources(viewer_lib_RCC_SRCS enki-viewer-textures.qrc)
 	
 	include_directories(${PROJECT_SOURCE_DIR})
-	
+
+	find_package(OpenGL REQUIRED)
+
 	add_library(enkiviewer ${viewer_lib_SRCS} ${viewer_lib_RCC_SRCS})
 	set_target_properties(enkiviewer PROPERTIES VERSION ${LIB_VERSION_STRING} 
                                         SOVERSION ${LIB_VERSION_MAJOR})


### PR DESCRIPTION
Changes needed to compile using Qt5 on the CI platform.

The changes to the build nodes needed to allow both Qt4 and Qt5 compilation are found in aseba-community/aseba-continuous-integration#2.