### PR TITLE
Cleanup fPIC mode

### DIFF
--- a/enki/CMakeLists.txt
+++ b/enki/CMakeLists.txt
@@ -1,7 +1,3 @@
-if (CMAKE_HOST_UNIX)
-	add_definitions("-fPIC")
-endif (CMAKE_HOST_UNIX)
-
 add_library(enki
 	Geometry.cpp
 	Types.cpp
@@ -24,8 +20,9 @@ add_library(enki
 
 target_include_directories (enki PUBLIC ${PROJECT_SOURCE_DIR})
 
-set_target_properties(enki PROPERTIES VERSION ${LIB_VERSION_STRING} 
-                                        SOVERSION ${LIB_VERSION_MAJOR})
+set_target_properties(enki PROPERTIES VERSION ${LIB_VERSION_STRING}
+										SOVERSION ${LIB_VERSION_MAJOR}
+										POSITION_INDEPENDENT_CODE ON)
 
 install(DIRECTORY . 
 	DESTINATION include/enki/


### PR DESCRIPTION
 * `CMAKE_HOST_UNIX` designs the host; `CMAKE_SYSTEM` is more adapted to manipulate a target - Notably because people ( me including may want to cross compile to windows) 
 * `add_definitions` should be reserved to `-D<DEFINE>` - what you wanted was `add_compile_options`
 * prefer a target-based approach so `target_compile_options`
 * Prefer properties to flags, in this case `POSITION_INDEPENDENT_CODE` 

`POSITION_INDEPENDENT_CODE` was the default for shared libs, not static one. I did not happen to make a static build of `enki`, hence the bug you encountered.