### PR TITLE
flake8, ref #8

### DIFF
--- a/python/test-gui.py
+++ b/python/test-gui.py
@@ -1,35 +1,37 @@
-import pyenki
+from __future__ import print_function
+
 import random
 
+import pyenki
+
+
 class MyEPuck(pyenki.EPuck):
-	
-	def __init__(self):
-		super(MyEPuck, self).__init__()
-		self.timeout = 10
-		
-	def controlStep(self, dt):
-		if self.timeout == 0:
-			self.leftSpeed = random.uniform(-100,100)
-			self.rightSpeed = random.uniform(-100,100)
-			self.timeout = random.randint(1,10)
-		else:
-			self.timeout -= 1
-		#print('Control step')
-		#print('pos: ' + str(self.pos))
-		#print('IR dists: ' + str(self.proximitySensorDistances))
-		#print('IR values: ' + str(self.proximitySensorValues))
-		#print('Cam image: ' + str(self.cameraImage))
-		#print len(self.cameraImage), self.cameraImage[0]
-		print id(self), self.pos
+    def __init__(self):
+        super(MyEPuck, self).__init__()
+        self.timeout = 10
+
+    def controlStep(self, dt):
+        if self.timeout == 0:
+            self.leftSpeed = random.uniform(-100, 100)
+            self.rightSpeed = random.uniform(-100, 100)
+            self.timeout = random.randint(1, 10)
+        else:
+            self.timeout -= 1
+        # print('Control step')
+        # print('pos: ' + str(self.pos))
+        # print('IR dists: ' + str(self.proximitySensorDistances))
+        # print('IR values: ' + str(self.proximitySensorValues))
+        # print('Cam image: ' + str(self.cameraImage))
+        # print(len(self.cameraImage), self.cameraImage[0])
+        print(id(self), self.pos)
 
 
 w = pyenki.World()
 
-for i in range(0,10):
-	for j in range(0,10):
-		e = MyEPuck()
-		e.pos = (i*10,j*10)
-		w.addObject(e)
+for i in range(0, 10):
+    for j in range(0, 10):
+        e = MyEPuck()
+        e.pos = (i * 10, j * 10)
+        w.addObject(e)
 
 w.runInViewer()
-

--- a/python/test.py
+++ b/python/test.py
@@ -1,24 +1,29 @@
-import pyenki
+from __future__ import print_function
+
 import math
 
+import pyenki
+
+
 class MyEPuck(pyenki.EPuck):
-	def controlStep(self, dt):
-		self.leftSpeed = 0.1
-		self.rightSpeed = 0.2
-		print('Control step')
-		print('pos: ' + str(self.pos))
-		print('IR dists: ' + str(self.proximitySensorDistances))
-		assert(not any(map(math.isnan, self.proximitySensorDistances)))
-		print('IR values: ' + str(self.proximitySensorValues))
-		assert(not any(map(math.isnan, self.proximitySensorValues)))
-		print('Cam image: ' + str(self.cameraImage))
-		print len(self.cameraImage), self.cameraImage[0]
+    def controlStep(self, dt):
+        self.leftSpeed = 0.1
+        self.rightSpeed = 0.2
+        print('Control step')
+        print('pos: ' + str(self.pos))
+        print('IR dists: ' + str(self.proximitySensorDistances))
+        assert (not any(map(math.isnan, self.proximitySensorDistances)))
+        print('IR values: ' + str(self.proximitySensorValues))
+        assert (not any(map(math.isnan, self.proximitySensorValues)))
+        print('Cam image: ' + str(self.cameraImage))
+        print(len(self.cameraImage), self.cameraImage[0])
+
 
 w = pyenki.World()
 e = MyEPuck()
-#e = pyenki.EPuck()
+# e = pyenki.EPuck()
 w.addObject(e)
 
 for i in range(10):
-	w.step(0.05)
-	print ''
+    w.step(0.05)
+    print()

--- a/tools/compute_ir_sensors_params.py
+++ b/tools/compute_ir_sensors_params.py
@@ -1,52 +1,57 @@
 #!/usr/bin/env python
+
+from __future__ import print_function
+
 import argparse
+import math
+
 import numpy as np
 from scipy.optimize import fmin
-from scipy.optimize import fmin_bfgs
-from scipy.optimize import anneal
+
 
 def main():
-	# parse arguments
-	parser = argparse.ArgumentParser(description='Tool to compute IR sensors from ')
-	parser.add_argument('distances', help='Array (a,b,...) of distances')
-	parser.add_argument('activations', help='Array (a,b,...) of activation values')
-	args = parser.parse_args()
-	x = map(float, args.distances.split(','))
-	y = map(float, args.activations.split(','))
-	if len(x) != len(y):
-		raise RuntimeError('distances array size %d is different than activations array size %d' % (len(x), len(y)))
-	print x,y
-	
-	# function to optimise
-	def F(v):
-		error = 0.
-		a = v[0]
-		b = v[1]
-		c = v[2]
-		for (xi,yi) in zip(x,y):
-			denom = (xi*xi + b*xi + c)
-			if abs(denom) < 1e-30:
-				denom = math.copysign(1e-30, denom)
-			err = (yi - a / denom)
-			error += err * err
-		#print error
-		return error
-	
-	# run optimisation
-	#res, Jmin = anneal(F, [10.,10.,10.], lower=-1e5, upper=1e5, maxiter=100000)
-	#print res, Jmin
-	best_val = 1e100
-	best_x = None
-	for i in range(1000):
-		init_x = np.random.normal(scale=1000,size=3)
-		#print init_x
-		res = fmin(F, init_x)
-		res_val = F(res)
-		if res_val < best_val:
-			print 'new best val ', best_val
-			best_val = res_val
-			best_x = res
-	print best_x, best_val
+    # parse arguments
+    parser = argparse.ArgumentParser(description='Tool to compute IR sensors from ')
+    parser.add_argument('distances', help='Array (a,b,...) of distances')
+    parser.add_argument('activations', help='Array (a,b,...) of activation values')
+    args = parser.parse_args()
+    x = map(float, args.distances.split(','))
+    y = map(float, args.activations.split(','))
+    if len(x) != len(y):
+        raise RuntimeError('distances array size %d is different than activations array size %d' % (len(x), len(y)))
+    print(x, y)
+
+    # function to optimise
+    def F(v):
+        error = 0.
+        a = v[0]
+        b = v[1]
+        c = v[2]
+        for (xi, yi) in zip(x, y):
+            denom = (xi * xi + b * xi + c)
+            if abs(denom) < 1e-30:
+                denom = math.copysign(1e-30, denom)
+            err = (yi - a / denom)
+            error += err * err
+        # print(error)
+        return error
+
+    # run optimisation
+    # res, Jmin = anneal(F, [10.,10.,10.], lower=-1e5, upper=1e5, maxiter=100000)
+    # print(res, Jmin)
+    best_val = 1e100
+    best_x = None
+    for i in range(1000):
+        init_x = np.random.normal(scale=1000, size=3)
+        # print(init_x)
+        res = fmin(F, init_x)
+        res_val = F(res)
+        if res_val < best_val:
+            print('new best val ', best_val)
+            best_val = res_val
+            best_x = res
+    print(best_x, best_val)
+
 
 if __name__ == '__main__':
-	main()
+    main()

--- a/tools/compute_ir_sensors_ray_weights.py
+++ b/tools/compute_ir_sensors_ray_weights.py
@@ -1,72 +1,80 @@
 #!/usr/bin/env python
+
+from __future__ import print_function
+
 import argparse
-import numpy as np
 import math
+
+import numpy as np
 from scipy.optimize import fmin
-from scipy.optimize import fmin_bfgs
-from scipy.optimize import anneal
+
 
 def main():
-	# parse arguments
-	parser = argparse.ArgumentParser(description='Tool to compute ray weights for 3 rays, using the well-known Colas wall-sliding method')
-	parser.add_argument('params', help='Parameters for activation function F')
-	parser.add_argument('dist', help='distance to the wall', type=float)
-	parser.add_argument('dmax', help='distance measured when not seeing anything', type=float)
-	parser.add_argument('angles', help='angles used for measurements')
-	parser.add_argument('distances', help='perceived distances at angles')
-	args = parser.parse_args()
-	p = map(float, args.params.split(','))
-	if len(p) != 3:
-		raise RuntimeError('you must provide 3 parameters for activation function F, but you provided %d' % p)
-	x = map(float, args.angles.split(','))
-	y = map(float, args.distances.split(','))
-	if len(x) != len(y):
-		raise RuntimeError('angle array size %d is different than distance array size %d' % (len(x), len(y)))
-	print p,x,y
-	
-	# activation function
-	def F(x):
-		return p[0] / (x*x + p[1]*x + p[2])
-	f_d0 = F(args.dist)
-	f_dmax = F(args.dmax)
-	
-	# function to optimise
-	def E(v,verbose=False):
-		error = 0.
-		angle = v[0]
-		w0 = v[1]
-		w1 = v[2]
-		f_d1 = F(args.dist / math.cos(math.radians(angle)))
-		def F_dsim(a):
-			if a < -angle:
-				return w1*f_d1 + w0*f_d0 + w1*f_d1
-			elif a < 0:
-				return w1*f_dmax + w0*f_d0 + w1*f_d1
-			elif a < angle:
-				return w1*f_dmax + w0*f_dmax + w1*f_d1
-			else:
-				return w1*f_dmax + w0*f_dmax + w1*f_dmax
-		for (xi,yi) in zip(x,y):
-			err = F(yi) - F_dsim(xi)
-			if verbose:
-				print('Angle: %f, dist: %f, F(dist): %f,  F_dsim: %f' % (xi, yi, F(yi), F_dsim(xi)))
-			error += err * err
-		#print error
-		return error
-	
-	best_val = 1e100
-	best_x = None
-	for i in range(100):
-		init_x = [max(np.abs(x))/3., abs(np.random.normal(scale=1)), abs(np.random.normal(scale=1))]
-		print init_x
-		res = fmin(E, init_x)
-		res_val = E(res)
-		if res_val < best_val:
-			print 'new best val ', best_val
-			best_val = res_val
-			best_x = res
-	print best_x, best_val
-	E(best_x, True)
+    # parse arguments
+    parser = argparse.ArgumentParser(
+        description='Tool to compute ray weights for 3 rays, using the well-known Colas wall-sliding method')
+    parser.add_argument('params', help='Parameters for activation function F')
+    parser.add_argument('dist', help='distance to the wall', type=float)
+    parser.add_argument('dmax', help='distance measured when not seeing anything', type=float)
+    parser.add_argument('angles', help='angles used for measurements')
+    parser.add_argument('distances', help='perceived distances at angles')
+    args = parser.parse_args()
+    p = map(float, args.params.split(','))
+    if len(p) != 3:
+        raise RuntimeError('you must provide 3 parameters for activation function F, but you provided %d' % p)
+    x = map(float, args.angles.split(','))
+    y = map(float, args.distances.split(','))
+    if len(x) != len(y):
+        raise RuntimeError('angle array size %d is different than distance array size %d' % (len(x), len(y)))
+    print(p, x, y)
+
+    # activation function
+    def F(x):
+        return p[0] / (x * x + p[1] * x + p[2])
+
+    f_d0 = F(args.dist)
+    f_dmax = F(args.dmax)
+
+    # function to optimise
+    def E(v, verbose=False):
+        error = 0.
+        angle = v[0]
+        w0 = v[1]
+        w1 = v[2]
+        f_d1 = F(args.dist / math.cos(math.radians(angle)))
+
+        def F_dsim(a):
+            if a < -angle:
+                return w1 * f_d1 + w0 * f_d0 + w1 * f_d1
+            elif a < 0:
+                return w1 * f_dmax + w0 * f_d0 + w1 * f_d1
+            elif a < angle:
+                return w1 * f_dmax + w0 * f_dmax + w1 * f_d1
+            else:
+                return w1 * f_dmax + w0 * f_dmax + w1 * f_dmax
+
+        for (xi, yi) in zip(x, y):
+            err = F(yi) - F_dsim(xi)
+            if verbose:
+                print('Angle: %f, dist: %f, F(dist): %f,  F_dsim: %f' % (xi, yi, F(yi), F_dsim(xi)))
+            error += err * err
+        # print(error)
+        return error
+
+    best_val = 1e100
+    best_x = None
+    for i in range(100):
+        init_x = [max(np.abs(x)) / 3., abs(np.random.normal(scale=1)), abs(np.random.normal(scale=1))]
+        print(init_x)
+        res = fmin(E, init_x)
+        res_val = E(res)
+        if res_val < best_val:
+            print('new best val ', best_val)
+            best_val = res_val
+            best_x = res
+    print(best_x, best_val)
+    E(best_x, True)
+
 
 if __name__ == '__main__':
-	main()
+    main()


### PR DESCRIPTION
Hi again,

This PR follows #61, after I found out that some python scripts might not work on python 3.

Then, to ensure that there is no syntax errors on those script neither in python2 nor 3, I used the flake8 linter with `python2 -m flake8` and `python3 -m flake8`.

Most changes are:
- whitespaces, around operators, after a `#`, and some tabs have been replaced by spaces. To see this PR more clearly, you can ignore this by [adding `?w=1` at the end of the url](https://github.com/enki-community/enki/pull/62/files?w=1)
- using the print function
- removing unused imports
- splitting lines that are too long